### PR TITLE
enable keepTimeAlive configuration

### DIFF
--- a/lib/config/schemas/gateway.config.json
+++ b/lib/config/schemas/gateway.config.json
@@ -8,10 +8,7 @@
           "type": "string"
         },
         "paths": {
-          "type": [
-            "string",
-            "array"
-          ],
+          "type": ["string", "array"],
           "items": {
             "type": "string"
           }
@@ -28,10 +25,7 @@
           }
         },
         "methods": {
-          "type": [
-            "string",
-            "array"
-          ],
+          "type": ["string", "array"],
           "items": {
             "type": "string"
           }
@@ -39,10 +33,7 @@
       }
     },
     "conditionAction": {
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "properties": {
         "action": {
           "type": "object",
@@ -55,9 +46,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "name"
-          ],
+          "required": ["name"],
           "default": {
             "name": "always"
           }
@@ -72,6 +61,9 @@
       "properties": {
         "port": {
           "type": "number"
+        },
+        "keepAliveTimeout": {
+          "type": "number"
         }
       }
     },
@@ -79,6 +71,9 @@
       "type": "object",
       "properties": {
         "port": {
+          "type": "number"
+        },
+        "keepAliveTimeout": {
           "type": "number"
         },
         "tls": {
@@ -119,17 +114,12 @@
               "type": "string"
             }
           },
-          "required": [
-            "port"
-          ]
+          "required": ["port"]
         }
       ]
     },
     "apiEndpoints": {
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "additionalProperties": {
         "anyOf": [
           {
@@ -145,10 +135,7 @@
       }
     },
     "serviceEndpoints": {
-      "type": [
-        "object",
-        "null"
-      ],
+      "type": ["object", "null"],
       "additionalProperties": {
         "type": "object",
         "properties": {
@@ -166,14 +153,10 @@
         },
         "oneOf": [
           {
-            "required": [
-              "url"
-            ]
+            "required": ["url"]
           },
           {
-            "required": [
-              "urls"
-            ]
+            "required": ["urls"]
           }
         ]
       }
@@ -185,11 +168,7 @@
       }
     },
     "pipelines": {
-      "type": [
-        "object",
-        "array",
-        "null"
-      ],
+      "type": ["object", "array", "null"],
       "additionalProperties": {
         "type": "object",
         "properties": {
@@ -225,9 +204,7 @@
             ]
           }
         },
-        "required": [
-          "policies"
-        ]
+        "required": ["policies"]
       }
     }
   }

--- a/lib/gateway/server.js
+++ b/lib/gateway/server.js
@@ -12,6 +12,9 @@ module.exports.bootstrap = function (app) {
   const httpServer = config.gatewayConfig.http ? http.createServer(app) : null;
   const httpsServer = config.gatewayConfig.https && config.gatewayConfig.https.tls ? createTlsServer(config.gatewayConfig.https, app) : null;
 
+  httpServer.keepAliveTimeout = config.gatewayConfig.http ? config.gatewayConfig.http.keepAliveTimeout : httpServer.keepAliveTimeout;
+  httpServer.keepAliveTimeout = config.gatewayConfig.https ? config.gatewayConfig.https.keepAliveTimeout : httpsServer.keepAliveTimeout;
+
   addOnCloseEventHandlingToServer(httpServer);
   addOnCloseEventHandlingToServer(httpsServer);
 
@@ -21,7 +24,7 @@ module.exports.bootstrap = function (app) {
   };
 };
 
-function createTlsServer (httpsConfig, app) {
+function createTlsServer(httpsConfig, app) {
   let defaultCert = null;
   const sniCerts = [];
 
@@ -74,7 +77,7 @@ function createTlsServer (httpsConfig, app) {
   return https.createServer(options, app);
 }
 
-function addOnCloseEventHandlingToServer (server) {
+function addOnCloseEventHandlingToServer(server) {
   if (server) {
     server.on('close', function () {
       eventBus.removeAllListeners();

--- a/lib/gateway/server.js
+++ b/lib/gateway/server.js
@@ -13,7 +13,7 @@ module.exports.bootstrap = function (app) {
   const httpsServer = config.gatewayConfig.https && config.gatewayConfig.https.tls ? createTlsServer(config.gatewayConfig.https, app) : null;
 
   httpServer.keepAliveTimeout = config.gatewayConfig.http ? config.gatewayConfig.http.keepAliveTimeout : httpServer.keepAliveTimeout;
-  httpServer.keepAliveTimeout = config.gatewayConfig.https ? config.gatewayConfig.https.keepAliveTimeout : httpsServer.keepAliveTimeout;
+  httpsServer.keepAliveTimeout = config.gatewayConfig.https ? config.gatewayConfig.https.keepAliveTimeout : httpsServer.keepAliveTimeout;
 
   addOnCloseEventHandlingToServer(httpServer);
   addOnCloseEventHandlingToServer(httpsServer);


### PR DESCRIPTION
Enable configuration of `keepAliveTimeout` for http/https server.

Can be configured by setting the property in `gateway.config.yml` inside the project where used.